### PR TITLE
Reset metrics after each epoch

### DIFF
--- a/embeddings_for_trees/models/treelstm2seq.py
+++ b/embeddings_for_trees/models/treelstm2seq.py
@@ -130,6 +130,7 @@ class TreeLSTM2Seq(LightningModule):
                 f"{step}/precision": metric.precision,
                 f"{step}/recall": metric.recall,
             }
+            self.__metrics[f"{step}_f1"].reset()
         self.log_dict(log, on_step=False, on_epoch=True)
 
     def training_epoch_end(self, step_outputs: EPOCH_OUTPUT):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-VERSION = "1.0.3"
+VERSION = "1.0.4"
 
 with open("README.md") as readme_file:
     readme = readme_file.read()


### PR DESCRIPTION
See [PR to code2seq](https://github.com/JetBrains-Research/code2seq/pull/112).

> Without resetting, metrics accumulate state over multiple epochs. It leads to the underestimation of metrics during training or subsequent testing iterations: while the model improves, metrics accumulate worse values (e.g., less true positives and more false positives).